### PR TITLE
Warn for skipping additional properties with no type

### DIFF
--- a/packages/core/src/__tests__/odd-models.spec.ts
+++ b/packages/core/src/__tests__/odd-models.spec.ts
@@ -149,3 +149,13 @@ test('empty additionalProperties', async() => {
 	expect(falseAdditionalProperties).toBeDefined()
 	expect(falseAdditionalProperties.additionalProperties).toBeNull()
 })
+
+test('additional properties no schema', async() => {
+	const result = await createTestDocument('odd-models/additional-properties-no-schema.yml', { expectLogWarnings: true })
+	expect(result).toBeDefined()
+
+	const emptyAdditionalProperties = result.schemas['NullableAdditionalProperties'] as CodegenObjectSchema
+	expect(emptyAdditionalProperties).toBeDefined()
+	expect(emptyAdditionalProperties.additionalProperties).toBeNull()
+
+})

--- a/packages/core/src/__tests__/odd-models/additional-properties-no-schema.yml
+++ b/packages/core/src/__tests__/odd-models/additional-properties-no-schema.yml
@@ -1,0 +1,14 @@
+openapi: 3.0.3
+info:
+  title: Additional Properties - No Schema
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    NullableAdditionalProperties:
+      type: object
+      properties:
+        one:
+          type: string
+      additionalProperties:
+        nullable: true

--- a/packages/core/src/process/schema/object.ts
+++ b/packages/core/src/process/schema/object.ts
@@ -1,4 +1,4 @@
-import { CodegenAllOfStrategy, CodegenHierarchySchema, CodegenInterfaceSchema, CodegenObjectSchema, CodegenSchemaPurpose, CodegenSchemaType, CodegenScope } from '@openapi-generator-plus/types'
+import { CodegenAllOfStrategy, CodegenHierarchySchema, CodegenInterfaceSchema, CodegenLogLevel, CodegenObjectSchema, CodegenSchemaPurpose, CodegenSchemaType, CodegenScope } from '@openapi-generator-plus/types'
 import { isOpenAPIv3SchemaObject } from '../../openapi-type-guards'
 import { InternalCodegenState } from '../../types'
 import { OpenAPIX } from '../../types/patches'
@@ -164,8 +164,12 @@ function handleObjectCommon<T extends CodegenObjectSchema | CodegenInterfaceSche
 
 	if (apiSchema.additionalProperties) {
 		/* This schema also has additional properties */
-		const mapSchema = toCodegenMapSchema(apiSchema, naming, 'value', schema, state)
-		schema.additionalProperties = mapSchema
+		try {
+			const mapSchema = toCodegenMapSchema(apiSchema, naming, 'value', schema, state)
+			schema.additionalProperties = mapSchema
+		} catch (error) {
+			state.log(CodegenLogLevel.WARN, `Failed to generate additional property schema: ${(error as Error).message}`)
+		}
 	}
 		
 	schema.discriminator = toCodegenSchemaDiscriminator(apiSchema, schema, state)


### PR DESCRIPTION
Additional properties with no type are currently unsupported due to the lack of an *any* type. Wild schemas continue to describe additional properties and offer no type so this patch should allow the generator to proceed with a warning that the additional properties were skipped.