### PR TITLE
Warn when allOf includes additionalProperties with no schema

### DIFF
--- a/packages/core/src/__tests__/odd-models.spec.ts
+++ b/packages/core/src/__tests__/odd-models.spec.ts
@@ -1,6 +1,6 @@
 import { createTestDocument, createTestGenerator } from './common'
 import { idx } from '../'
-import { CodegenObjectSchema, CodegenSchemaType, CodegenOneOfStrategy, CodegenWrapperSchema, CodegenMapSchema } from '@openapi-generator-plus/types'
+import { CodegenObjectSchema, CodegenSchemaType, CodegenOneOfStrategy, CodegenWrapperSchema, CodegenMapSchema, CodegenAllOfStrategy } from '@openapi-generator-plus/types'
 
 test('array of strings without collection models', async() => {
 	const result = await createTestDocument('odd-models/array-of-strings-v2.yml')
@@ -151,7 +151,7 @@ test('empty additionalProperties', async() => {
 })
 
 test('additional properties no schema', async() => {
-	const result = await createTestDocument('odd-models/additional-properties-no-schema.yml', { expectLogWarnings: true })
+	const result = await createTestDocument('odd-models/additional-properties-no-schema.yml', { expectLogWarnings: true, allOfStrategy: CodegenAllOfStrategy.OBJECT })
 	expect(result).toBeDefined()
 
 	const emptyAdditionalProperties = result.schemas['NullableAdditionalProperties'] as CodegenObjectSchema

--- a/packages/core/src/__tests__/odd-models.spec.ts
+++ b/packages/core/src/__tests__/odd-models.spec.ts
@@ -158,4 +158,8 @@ test('additional properties no schema', async() => {
 	expect(emptyAdditionalProperties).toBeDefined()
 	expect(emptyAdditionalProperties.additionalProperties).toBeNull()
 
+	const reffingAdditionalProperties = result.schemas['ReffingNullableAdditionalProperties'] as CodegenObjectSchema
+	expect(reffingAdditionalProperties).toBeDefined()
+	expect(reffingAdditionalProperties.additionalProperties).toBeFalsy()
+
 })

--- a/packages/core/src/__tests__/odd-models/additional-properties-no-schema.yml
+++ b/packages/core/src/__tests__/odd-models/additional-properties-no-schema.yml
@@ -5,6 +5,15 @@ info:
 paths: {}
 components:
   schemas:
+    ReffingNullableAdditionalProperties:
+      allOf:
+        - $ref: "#/components/schemas/NullableAdditionalProperties"
+        - type: object
+          additionalProperties:
+            nullable: true
+          properties:
+            two:
+              type: string
     NullableAdditionalProperties:
       type: object
       properties:

--- a/packages/core/src/process/schema/object-absorb.ts
+++ b/packages/core/src/process/schema/object-absorb.ts
@@ -1,4 +1,4 @@
-import { CodegenNamedSchemas, CodegenObjectLikeSchemas, CodegenObjectSchema, CodegenProperties, CodegenSchema, CodegenSchemaPurpose, CodegenScope, isCodegenMapSchema, isCodegenObjectLikeSchema } from '@openapi-generator-plus/types'
+import { CodegenLogLevel, CodegenNamedSchemas, CodegenObjectLikeSchemas, CodegenObjectSchema, CodegenProperties, CodegenSchema, CodegenSchemaPurpose, CodegenScope, isCodegenMapSchema, isCodegenObjectLikeSchema } from '@openapi-generator-plus/types'
 import * as idx from '@openapi-generator-plus/indexed-type'
 import { OpenAPIX } from '../../types/patches'
 import { InternalCodegenState } from '../../types'
@@ -72,9 +72,13 @@ export function absorbApiSchema(apiSchema: OpenAPIX.SchemaObject, target: Codege
 				throw new Error(`Cannot absorb schema as the target already has additionalProperties: ${debugStringify(apiSchema)}`)
 			}
 
-			const mapSchema = toCodegenMapSchema(apiSchema, null, 'value', target, state)
-			target.additionalProperties = mapSchema
-			absorbed = true
+			try {
+				const mapSchema = toCodegenMapSchema(apiSchema, null, 'value', target, state)
+				target.additionalProperties = mapSchema
+				absorbed = true
+			} catch (error) {
+				state.log(CodegenLogLevel.WARN, `Failed to absorb additional property schema into ${target.name}: ${(error as Error).message}`)
+			}
 		}
 
 		if (absorbed) {

--- a/packages/core/src/process/schema/object-absorb.ts
+++ b/packages/core/src/process/schema/object-absorb.ts
@@ -57,7 +57,7 @@ export function absorbApiSchema(apiSchema: OpenAPIX.SchemaObject, target: Codege
 			If the other schema is inline, and we can just absorb its properties and any sub-schemas it creates,
 			then we do. We absorb the sub-schemas it creates by passing this model as to scope to toCodegenProperties.
 
-			This will not work in the inline schema is not an object schema, or is an allOf, oneOf, anyOf etc, in which
+			This will not work if the inline schema is not an object schema, or is an allOf, oneOf, anyOf etc, in which
 			case we fall back to using toCodegenSchemaUsage.
 			*/
 

--- a/packages/core/src/process/schema/object.ts
+++ b/packages/core/src/process/schema/object.ts
@@ -168,7 +168,7 @@ function handleObjectCommon<T extends CodegenObjectSchema | CodegenInterfaceSche
 			const mapSchema = toCodegenMapSchema(apiSchema, naming, 'value', schema, state)
 			schema.additionalProperties = mapSchema
 		} catch (error) {
-			state.log(CodegenLogLevel.WARN, `Failed to generate additional property schema: ${(error as Error).message}`)
+			state.log(CodegenLogLevel.WARN, `Failed to generate additional property schema for ${naming.name} ${schema.additionalProperties}: ${(error as Error).message}`)
 		}
 	}
 		


### PR DESCRIPTION
This is a workaround to deal with absorbing objects that have poorly defined additionalProperties.

Improved the warnings to include the schema names so that discovering the source of the warning is easier.